### PR TITLE
add missing dependencies for Python 3.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
     - textnets = textnets.cli:main
@@ -31,6 +31,8 @@ requirements:
     - scipy >=1.4
     - toolz
     - leidenalg
+    - typing-extensions
+    - cached-property
 
 test:
   imports:


### PR DESCRIPTION
For Python 3.7 compatibility, `typing-extensions` and `cached-property` are needed. New build number is 1.